### PR TITLE
fixing pointToSpend bug and only removing carrier trait if purchased

### DIFF
--- a/Contents/mods/ZContagion_Traits/media/lua/client/zcontagion/traitcode.lua
+++ b/Contents/mods/ZContagion_Traits/media/lua/client/zcontagion/traitcode.lua
@@ -7,13 +7,27 @@ SandboxOptionsScreen.setSandboxVars = function(self)
     local trait = TraitFactory.getTrait("Carrier")
     local ccp = MainScreen.instance.charCreationProfession
 
+    
     --cleanup old trait
     local label = trait:getLabel()
-    local olditem = ccp.listboxTrait:removeItem(label)
+    
+    --determine if trait is purchased before clearing ccp.listboxTraitSelected
+    local traitIsPurchased = false
+    for _,v in ipairs(ccp.listboxTraitSelected.items) do
+        if v.item:getLabel() == label then 
+            traitIsPurchased = true 
+        end
+    end
+
+    --only remove traits if the price has actually changed
+    local oldItem 
+    if(previousPrice ~= trait:getCost()) then
+        oldItem = ccp.listboxTrait:removeItem(label)
             or ccp.listboxBadTrait:removeItem(label)
             or ccp.listboxTraitSelected:removeItem(label)
+    end
 
-    if olditem then -- readd it
+    if oldItem then -- readd it
         local newItem
         if trait:getCost() > 0 then
             newItem = ccp.listboxTrait:addItem(label, trait)
@@ -21,8 +35,12 @@ SandboxOptionsScreen.setSandboxVars = function(self)
             newItem = ccp.listboxBadTrait:addItem(label, trait)
         end
         newItem.tooltip = trait:getDescription()
-        ccp.pointToSpend = ccp.pointToSpend + previousPrice
-
+        
+        --adjust available points only if traitIsPurchased
+        if traitIsPurchased then
+            ccp.pointToSpend = ccp.pointToSpend + previousPrice
+        end
+        
         CharacterCreationMain.sort(ccp.listboxTrait.items)
         CharacterCreationMain.invertSort(ccp.listboxBadTrait.items)
         CharacterCreationMain.sort(ccp.listboxTraitSelected.items)


### PR DESCRIPTION
This PR resolves a small bug with pointToSpend. Repeated hits to the Occupation screen can incorrectly give or steal points from the player.  This is resolved by creating a variable traitIsPurchased. This variable checks to see if the trait in question is purchased or not. If the trait is purchased we reward the necessary points. If it is not purchased we don't need to change pointToSpend.

This mod also offers a small solution to removing the trait when the trait cost has not been changed. As long as the sandbox variable for trait cost hasn't changed, we can leave it where it is and not adjust the player's available points. 

For more information and replication steps, please see https://www.youtube.com/watch?v=38MePs1ozKI